### PR TITLE
correciones y ajustes

### DIFF
--- a/src/sections/encuestas/crear-nueva-encuesta-formulario.jsx
+++ b/src/sections/encuestas/crear-nueva-encuesta-formulario.jsx
@@ -202,18 +202,18 @@ export default function InvoiceNewEditForm() {
         title="¿Deseas activar la encuesta?"
         action={
           <>
-            <Button variant="contained" onClick={() => {
-              handleCreateAndSend(1);
-              confirm.onFalse();
-            }}>
-              Si
-            </Button>
-            <Button variant="contained" loading={btnLoad} onClick={() => {
+            <Button variant="contained" color="error" loading={btnLoad} onClick={() => {
               setBtnLoad(true);
               confirm.onFalse();
               handleCreateAndSend(0);
             }}>
               No
+            </Button>
+            <Button variant="contained" color="success" onClick={() => {
+              handleCreateAndSend(1);
+              confirm.onFalse();
+            }}>
+              Si
             </Button>
           </>
         }

--- a/src/sections/encuestas/encuesta-detalle.jsx
+++ b/src/sections/encuestas/encuesta-detalle.jsx
@@ -67,12 +67,12 @@ export default function FormularioEncuesta({ idEncuesta }) {
                     )}
 
                     {item.respuestas === "5" && (
-                      <Typography variant="subtitle2" > Respuesta: Abierta corta </Typography>
+                      <Typography variant="subtitle2" > Respuesta: Abierta </Typography>
                     )}
 
-                    {item.respuestas === "6" && (
+                    {/* {item.respuestas === "6" && (
                       <Typography variant="subtitle2" > Respuestas: Abierta larga </Typography>
-                    )}
+                    )} */}
 
                   </Stack>
                 ))}

--- a/src/sections/encuestas/encuestas-tabla-barra.jsx
+++ b/src/sections/encuestas/encuestas-tabla-barra.jsx
@@ -18,7 +18,8 @@ export default function UserTableToolbar({
   filters,
   onFilters,
   roleOptions,
-  handleChangeId
+  handleChangeId,
+  rol,
 }) {
 
   const handleFilterName = useCallback(
@@ -57,6 +58,7 @@ export default function UserTableToolbar({
           pr: { xs: 2.5, md: 1 },
         }}
       >
+        {rol === 4 ? (
         <FormControl
           sx={{
             flexShrink: 0,
@@ -83,6 +85,10 @@ export default function UserTableToolbar({
           </Select>
         </FormControl>
 
+        ):(
+          null
+        )}
+
         <Stack direction="row" alignItems="center" spacing={2} flexGrow={1} sx={{ width: 1 }}>
           <TextField
             fullWidth
@@ -108,4 +114,5 @@ UserTableToolbar.propTypes = {
   onFilters: PropTypes.func,
   roleOptions: PropTypes.any,
   handleChangeId: PropTypes.any,
+  rol: PropTypes.any
 };

--- a/src/sections/encuestas/encuestasLista.jsx
+++ b/src/sections/encuestas/encuestasLista.jsx
@@ -35,7 +35,7 @@ const TABLE_HEAD = [
   { id: '', label: 'ID' },
   { id: '', label: 'FECHA CREACIÓN' },
   { id: '', label: 'ESTATUS' },
-  { id: '', label: 'DÍAS HABILES' },
+  { id: '', label: 'DÍAS HÁBILES' },
   { id: '', label: '' },
 ];
 
@@ -148,6 +148,7 @@ export default function EncuestasLista({ encuestas, estatusCt }) {
           onFilters={handleFilters}
           roleOptions={especialistas}
           handleChangeId={handleChangeId}
+          rol={user?.idRol}
           //
         />
 

--- a/src/sections/encuestas/formulario-encuesta.jsx
+++ b/src/sections/encuestas/formulario-encuesta.jsx
@@ -159,12 +159,12 @@ export default function FormularioEncuesta({ idEncuesta }) {
                     )}
 
                     {item.respuestas === "5" || item.respuestas === 5 && (
-                      <RHFTextField name={`resp_${index}`} />
+                      <RHFTextField name={`resp_${index}`}  multiline rows={4}/>
                     )}
 
-                    {item.respuestas === "6" || item.respuestas === 6 && (
+                    {/* {item.respuestas === "6" || item.respuestas === 6 && (
                       <RHFTextField name={`resp_${index}`} multiline rows={4} />
-                    )}
+                    )} */}
 
                     {/* <Controller
                     name={`pgt_${index}`}

--- a/src/sections/encuestas/modal-ver-encuesta.jsx
+++ b/src/sections/encuestas/modal-ver-encuesta.jsx
@@ -66,12 +66,12 @@ export default function UserQuickEditForm({ open, onClose, idEncuesta }) {
             )}
 
             {item.respuestas === "5" || item.respuestas === 5 && (
-              <DialogContent> Respuesta: Abierta corta </DialogContent>
+              <DialogContent> Respuesta: Abierta </DialogContent>
             )}
 
-            {item.respuestas === "6" || item.respuestas === 6 && (
+            {/* {item.respuestas === "6" || item.respuestas === 6 && (
               <DialogContent> Respuestas: Abierta larga </DialogContent>
-            )}
+            )} */}
 
             <Divider sx={{ my: 1, borderStyle: 'dashed' }} />
           </ React.Fragment>

--- a/src/sections/reportes/barratareas-tabla-citas.jsx
+++ b/src/sections/reportes/barratareas-tabla-citas.jsx
@@ -40,6 +40,7 @@ export default function BarraTareasTabla({
   rol,
   _eu,
   idUsuario,
+
 }) {
   const popover = usePopover();
 
@@ -71,7 +72,7 @@ export default function BarraTareasTabla({
     fhI: fechaI,
     fhF: fechaF,
     roles: rol,
-    idUsr: idUsuario, 
+    idUsr: idUsuario,
     idEsp: selectEsp,
   });
 
@@ -296,35 +297,41 @@ export default function BarraTareasTabla({
           null
         )}
 
-        <FormControl
-          sx={{
-            flexShrink: 0,
-            width: { xs: 1, md: 200 },
-          }}
-        >
-          <InputLabel>Especialistas</InputLabel>
+        {rol !== 3 ? (
 
-          <Select
-            multiple
-            disabled={condi}
-            value={filters.especialista}
-            onChange={handleFilterEspe}
-            input={<OutlinedInput label="Especialistas" />}
-            renderValue={(selected) => selected.map((value) => value).join(', ')}
-            MenuProps={{
-              PaperProps: {
-                sx: { maxHeight: 240 },
-              },
+          <FormControl
+            sx={{
+              flexShrink: 0,
+              width: { xs: 1, md: 200 },
             }}
           >
-            {_esp.map((option) => (
-              <MenuItem key={option} value={option}>
-                <Checkbox disableRipple size="small" checked={filters.especialista.includes(option)} />
-                {option}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+            <InputLabel>Especialistas</InputLabel>
+
+            <Select
+              multiple
+              disabled={condi}
+              value={filters.especialista}
+              onChange={handleFilterEspe}
+              input={<OutlinedInput label="Especialistas" />}
+              renderValue={(selected) => selected.map((value) => value).join(', ')}
+              MenuProps={{
+                PaperProps: {
+                  sx: { maxHeight: 240 },
+                },
+              }}
+            >
+              {_esp.map((option) => (
+                <MenuItem key={option} value={option}>
+                  <Checkbox disableRipple size="small" checked={filters.especialista.includes(option)} />
+                  {option}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+        ) : (
+          null
+        )}
 
         <DatePicker
           label="Fecha inicio"

--- a/src/sections/reportes/view/historial-reportes-view.jsx
+++ b/src/sections/reportes/view/historial-reportes-view.jsx
@@ -157,6 +157,8 @@ export default function HistorialReportesView() {
 
   const idUsuario = user?.idUsuario;
 
+  const nombreUser = user?.nombre;
+
   let TABLE_HEAD = [];
 
   let header = [];
@@ -187,6 +189,8 @@ export default function HistorialReportesView() {
   const _eu = esp.flatMap((es) => (es.puesto));
 
   defaultFilters.area = user?.idRol !== 4 ? _eu : [];
+
+  defaultFilters.especialista = user?.idRol === 3 ? nombreUser : [];
 
   const table = useTable();
 
@@ -356,6 +360,7 @@ export default function HistorialReportesView() {
             rol={rol}
             _eu={_eu}
             idUsuario={idUsuario}
+            nombreUser={nombreUser}
           />
 
           {canReset && (

--- a/src/utils/axios.js
+++ b/src/utils/axios.js
@@ -195,6 +195,7 @@ export const endpoints = {
     getCtCanceladas: '/GeneralController/getCtCanceladas',
     getCtPenalizadas: '/GeneralController/getCtPenalizadas',
     getMetas: '/DashboardController/getMetas',
+    getMetaAdmin: '/DashboardController/getMetaAdmin'
   },
   encuestas: {
     encuestaInsert: '/EncuestasController/encuestaInsert',


### PR DESCRIPTION
- Dashboard en el fichero de metas de citas está mostrando valores negativos.
- Al tratar de crear las encuestas no se ejecutaba la acción y no se visualizaba nada.
- No mostrar selector de especialista si es un especialista en el módulo de "Historial Reportes"
- Colocar acento en el apartado de días hábiles.
- En el módulo de crear encuestas se va a quitar las opciones de resupuestas: "Respuesta corta y larga" se quedaría solamente como "Respuesta abierta"
- Colocar acento en el apartado de días hábiles, en el módulo de ver encuestas.