### PR TITLE
Corrección en Icono mal posicionado en ventana de pago 

### DIFF
--- a/src/sections/calendar/beneficiary/pendingModalUser.jsx
+++ b/src/sections/calendar/beneficiary/pendingModalUser.jsx
@@ -344,7 +344,7 @@ export default function PendingModalUser({ idUsuario }) {
                   }
                 >
                   <ListItemText
-                    sx={{ width: '60%' }}
+                    sx={{ width: '50%' }}
                     primary={`${pending.beneficio} - ${pending.especialista}`}
                   />
                   <ListItemText


### PR DESCRIPTION
Se le disminuyo el tamaño al contenedor del titulo de la cita para que los botones de pago y cancelación tuvieran más espacio y no se sobrepusieran en el texto de la fecha de la cita.